### PR TITLE
Update Adafruit_BMP3XX.cpp

### DIFF
--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -162,8 +162,8 @@ bool Adafruit_BMP3XX::begin(uint8_t addr, TwoWire *theWire) {
   setPressureOversampling(BMP3_NO_OVERSAMPLING);
   setIIRFilterCoeff(BMP3_IIR_FILTER_DISABLE);
 
-  // don't do anything till we request a reading
-  the_sensor.settings.op_mode = BMP3_FORCED_MODE;
+  // select normal mode
+  the_sensor.settings.op_mode = BMP3_NORMAL_MODE;
 
   return true;
 }

--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -161,7 +161,10 @@ bool Adafruit_BMP3XX::begin(uint8_t addr, TwoWire *theWire) {
   setTemperatureOversampling(BMP3_NO_OVERSAMPLING);
   setPressureOversampling(BMP3_NO_OVERSAMPLING);
   setIIRFilterCoeff(BMP3_IIR_FILTER_DISABLE);
-
+  
+  // select forced mode 
+  // the_sensor.settings.op_mode = BMP3_FORCED_MODE;
+  
   // select normal mode
   the_sensor.settings.op_mode = BMP3_NORMAL_MODE;
 


### PR DESCRIPTION
Changed to normal mode (line 166)
This mode is recommended in the specification using IIR filter. (page 10)
Power consumption  is hardly affected  and depend on output data rate. 
Force mode is doing just one measurement and then go to sleep. normal mode cycles  between measurement and stby (see chapter 3.3.4 page 12)

