### PR TITLE
Deleted delay(40) - causes i2c hangs on Teensy 4.x

### DIFF
--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -350,8 +350,7 @@ bool Adafruit_BMP3XX::performReading(void) {
   rslt = bmp3_set_op_mode(&the_sensor);
   if (rslt != BMP3_OK)
     return false;
-
-  delay(40);
+  
 
   /* Variable used to store the compensated data */
   struct bmp3_data data;


### PR DESCRIPTION
This PR is a result of issue #13.

As a result of user testing on a Teensy 4.1 it was found that reading data from the sensor would fail with the following error
```
Setting sensor settings
Setting power mode
Getting sensor data
Failed to perform reading 
Setting sensor settings
Failed to perform reading 
```
See PJRC forum thread: https://forum.pjrc.com/threads/65656-Adafruit-BMP390-over-I2C-with-Wire-h-on-Teensy-3-6-ok-but-not-for-Teensy-4-1?highlight=BMP390.  

After some further testing with the Adafruit BMP390 it was found that deleting the delay(40) was the hang up.  Did a bit of research but didn't see a reason for the delay(40) except it was in the example.  The proposed changed was tested on a  Arduino Uno, Due, Mega, Teensy 4.1 and Teensy 3.5.  Another user tested the BMP388 on a Teensy 3.5.  Not sure what other boards should be tested.