### PR TITLE
fixed slow processing ... put into continuous mode and can get 200Hz sampling

### DIFF
--- a/Adafruit_BMP3XX.h
+++ b/Adafruit_BMP3XX.h
@@ -68,7 +68,6 @@ public:
 private:
   bool _init(void);
 
-  bool _filterEnabled, _tempOSEnabled, _presOSEnabled, _ODREnabled;
   uint8_t _i2caddr;
   int32_t _sensorID;
   int8_t _cs;

--- a/examples/bmp3xx_simpletest/bmp3xx_simpletest.ino
+++ b/examples/bmp3xx_simpletest/bmp3xx_simpletest.ino
@@ -32,20 +32,45 @@ Adafruit_BMP3XX bmp;
 void setup() {
   Serial.begin(115200);
   while (!Serial);
-  Serial.println("Adafruit BMP388 / BMP390 test");
+
+  Wire.setClock(100000); // 100 kHz
+  // Wire.setClock(400000); // 400 kHz
 
   if (!bmp.begin_I2C()) {   // hardware I2C mode, can pass in address & alt Wire
-  //if (! bmp.begin_SPI(BMP_CS)) {  // hardware SPI mode  
+  //if (! bmp.begin_SPI(BMP_CS)) {  // hardware SPI mode
   //if (! bmp.begin_SPI(BMP_CS, BMP_SCK, BMP_MISO, BMP_MOSI)) {  // software SPI mode
     Serial.println("Could not find a valid BMP3 sensor, check wiring!");
     while (1);
   }
 
   // Set up oversampling and filter initialization
-  bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_8X);
-  bmp.setPressureOversampling(BMP3_OVERSAMPLING_4X);
-  bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_3);
-  bmp.setOutputDataRate(BMP3_ODR_50_HZ);
+  // Datasheet, table 9, pg 17
+  if (1) {
+        // Drone
+        // Mode: Normal
+        // OS Pres: x8
+        // OS Temp: x1
+        // IIR: 2 -> 3
+        // Sampling: 50Hz
+        // RMS Noise [cm]: 11
+        bmp.setTemperatureOversampling(BMP3_NO_OVERSAMPLING);
+        bmp.setPressureOversampling(BMP3_OVERSAMPLING_8X);
+        bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_3);
+        bmp.setOutputDataRate(BMP3_ODR_50_HZ);
+    }
+    else {
+        // Indoor nav
+        // Mode: Normal
+        // OS Pres: x16
+        // OS Temp: x2
+        // IIR: 4 -> 15
+        // Sampling: 25Hz
+        // RMS Noise [cm]: 5
+        bmp.setTemperatureOversampling(BMP3_OVERSAMPLING_2X);
+        bmp.setPressureOversampling(BMP3_OVERSAMPLING_16X);
+        bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_COEFF_15);
+        bmp.setOutputDataRate(BMP3_ODR_25_HZ);
+    }
 }
 
 void loop() {
@@ -53,18 +78,10 @@ void loop() {
     Serial.println("Failed to perform reading :(");
     return;
   }
-  Serial.print("Temperature = ");
-  Serial.print(bmp.temperature);
-  Serial.println(" *C");
 
-  Serial.print("Pressure = ");
-  Serial.print(bmp.pressure / 100.0);
-  Serial.println(" hPa");
+  // Serial.println(bmp.temperature, 1);       // C
+  Serial.println(bmp.pressure / 100.0, 3);  // hPa
+  // Serial.println(bmp.readAltitude(SEALEVELPRESSURE_HPA), 3); // m
 
-  Serial.print("Approx. Altitude = ");
-  Serial.print(bmp.readAltitude(SEALEVELPRESSURE_HPA));
-  Serial.println(" m");
-
-  Serial.println();
-  delay(2000);
+  delay(10); // ~100Hz
 }


### PR DESCRIPTION
Sensor running forced mode which didn't allow me to go much beyond 100Hz. But, page 12, section 3.3.3 says continuous mode allows you to get to 200 Hz. So I changed it so it sets continuous mode and just runs ... you can easily get 200Hz without blocking due to setting up the sensor everytime you want to sample (which slowed you down).