### PR TITLE
Support multiple sensors

### DIFF
--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -469,7 +469,7 @@ bool Adafruit_BMP3XX::setIIRFilterCoeff(uint8_t filtercoeff) {
 
 */
 /**************************************************************************/
-bool Adafruit_BMP3XX::Adafruit_BMP3XX::setOutputDataRate(uint8_t odr) {
+bool Adafruit_BMP3XX::setOutputDataRate(uint8_t odr) {
   if (odr > BMP3_ODR_0_001_HZ)
     return false;
 

--- a/Adafruit_BMP3XX.h
+++ b/Adafruit_BMP3XX.h
@@ -66,6 +66,9 @@ public:
   double pressure;
 
 private:
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
+
   bool _init(void);
 
   bool _filterEnabled, _tempOSEnabled, _presOSEnabled, _ODREnabled;


### PR DESCRIPTION
For #16 and maybe #18. Add support for multiple sensors. Sort of a hack, but tested and works. Basic idea is to add new class members for `i2c_dev` and `spi_dev` and then dynamically set them to the global ones for each read method.

Do **not** have BMP390 to test.

### Multiple SPI Test
![bmp388_multi_spi](https://user-images.githubusercontent.com/8755041/122609646-31a8fd00-d033-11eb-86c1-66057d7e84e2.jpg)

```cpp
#include "Adafruit_BMP3XX.h"

#define BMP1_CS 7
#define BMP2_CS 9

Adafruit_BMP3XX bmp1;
Adafruit_BMP3XX bmp2;

void setup() {
  Serial.begin(115200);
  while (!Serial);
  Serial.println("Adafruit BMP388 / BMP390 test");

  if (! bmp1.begin_SPI(BMP1_CS)) {  // hardware SPI mode  
    Serial.println("Could not find a valid BMP sensor #1, check wiring!");
    while (1);
  }

  if (! bmp2.begin_SPI(BMP2_CS)) {  // hardware SPI mode  
    Serial.println("Could not find a valid BMP sensor #2, check wiring!");
    while (1);
  }

  Serial.println("Initialization Success!");
}

void loop() {
  if (! bmp1.performReading()) {
    Serial.println("Failed to perform reading BMP #1 :(");
    return;
  }
  Serial.print("BMP #1 Temperature = ");
  Serial.print(bmp1.temperature);
  Serial.println(" *C");

  if (! bmp2.performReading()) {
    Serial.println("Failed to perform reading BMP #2 :(");
    return;
  }
  Serial.print("BMP #2 Temperature = ");
  Serial.print(bmp2.temperature);
  Serial.println(" *C");

  delay(2000);
  
}
```

### Multiple I2C Test
![bmp388_multi_i2c](https://user-images.githubusercontent.com/8755041/122609681-3c639200-d033-11eb-9388-c8b45e9bc01f.jpg)

```cpp
#include "Adafruit_BMP3XX.h"

Adafruit_BMP3XX bmp1;
Adafruit_BMP3XX bmp2;

void setup() {
  Serial.begin(115200);
  while (!Serial);
  Serial.println("Adafruit BMP388 / BMP390 test");

  if (! bmp1.begin_I2C()) {  
    Serial.println("Could not find a valid BMP sensor #1, check wiring!");
    while (1);
  }

  if (! bmp2.begin_I2C(0x76)) {  
    Serial.println("Could not find a valid BMP sensor #2, check wiring!");
    while (1);
  }

  Serial.println("Initialization Success!");
}

void loop() {
  if (! bmp1.performReading()) {
    Serial.println("Failed to perform reading BMP #1 :(");
    return;
  }
  Serial.print("BMP #1 Temperature = ");
  Serial.print(bmp1.temperature);
  Serial.println(" *C");

  if (! bmp2.performReading()) {
    Serial.println("Failed to perform reading BMP #2 :(");
    return;
  }
  Serial.print("BMP #2 Temperature = ");
  Serial.print(bmp2.temperature);
  Serial.println(" *C");

  delay(2000);
  
}
```

Both work and print out expected results. Can breathe on second sensor and see its temp value rise.
![Screenshot from 2021-06-18 12-36-24](https://user-images.githubusercontent.com/8755041/122609877-8f3d4980-d033-11eb-8aaf-0626cc1c2619.png)

 