### PR TITLE
Change I2C write to have stop

### DIFF
--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -506,7 +506,7 @@ int8_t i2c_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len,
   // Serial.print("I2C write address 0x"); Serial.print(reg_addr, HEX);
   // Serial.print(" len "); Serial.println(len, HEX);
 
-  if (!g_i2c_dev->write((uint8_t *)reg_data, len, false, &reg_addr, 1))
+  if (!g_i2c_dev->write((uint8_t *)reg_data, len, true, &reg_addr, 1))
     return 1;
 
   return 0;


### PR DESCRIPTION
For #20.

Looks like maybe a minor bug that was always there - why suppress i2c stop on the write? And just getting away with it on other BSPs. Change in this PR fixes #20 and also does not break other boards tested, using `bmp3xx_simpletest.ino` example from library.

**Feather ESP32**
![Screenshot from 2021-10-26 12-44-57](https://user-images.githubusercontent.com/8755041/138951461-56eca700-98f4-4542-a1fa-e9faef88c449.png)


**Metro ESP32-S2**
![Screenshot from 2021-10-26 12-49-00](https://user-images.githubusercontent.com/8755041/138951468-5017f879-9c97-4607-992c-1bc92a364c2a.png)


**QTPy SAMD M0**
![Screenshot from 2021-10-26 12-52-10](https://user-images.githubusercontent.com/8755041/138951482-b09034c3-3241-4bed-8846-2f788dd966e6.png)


