### PR TITLE
Enable custom SPI clock speed

### DIFF
--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -101,6 +101,7 @@ bool Adafruit_BMP3XX::begin_I2C(uint8_t addr, TwoWire *theWire) {
  *    @brief  Sets up the hardware and initializes hardware SPI
  *    @param  cs_pin The arduino pin # connected to chip select
  *    @param  theSPI The SPI object to be used for SPI connections.
+ *    @param  frequency The SPI bus frequency
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
@@ -138,6 +139,7 @@ bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
  *    @param  sck_pin The arduino pin # connected to SPI clock
  *    @param  miso_pin The arduino pin # connected to SPI MISO
  *    @param  mosi_pin The arduino pin # connected to SPI MOSI
+ *    @param  frequency The SPI bus frequency
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_BMP3XX::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,

--- a/Adafruit_BMP3XX.cpp
+++ b/Adafruit_BMP3XX.cpp
@@ -103,7 +103,8 @@ bool Adafruit_BMP3XX::begin_I2C(uint8_t addr, TwoWire *theWire) {
  *    @param  theSPI The SPI object to be used for SPI connections.
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
+bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI,
+                                uint32_t frequency) {
   if (i2c_dev)
     delete i2c_dev;
   if (spi_dev)
@@ -112,7 +113,7 @@ bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
 
   g_spi_dev = spi_dev =
       new Adafruit_SPIDevice(cs_pin,
-                             BMP3XX_DEFAULT_SPIFREQ, // frequency
+                             frequency,              // frequency
                              SPI_BITORDER_MSBFIRST,  // bit order
                              SPI_MODE0,              // data mode
                              theSPI);
@@ -140,7 +141,7 @@ bool Adafruit_BMP3XX::begin_SPI(uint8_t cs_pin, SPIClass *theSPI) {
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_BMP3XX::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                                int8_t mosi_pin) {
+                                int8_t mosi_pin, uint32_t frequency) {
   if (i2c_dev)
     delete i2c_dev;
   if (spi_dev)
@@ -149,7 +150,7 @@ bool Adafruit_BMP3XX::begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
 
   g_spi_dev = spi_dev =
       new Adafruit_SPIDevice(cs_pin, sck_pin, miso_pin, mosi_pin,
-                             BMP3XX_DEFAULT_SPIFREQ, // frequency
+                             frequency,              // frequency
                              SPI_BITORDER_MSBFIRST,  // bit order
                              SPI_MODE0);             // data mode
 

--- a/Adafruit_BMP3XX.h
+++ b/Adafruit_BMP3XX.h
@@ -44,9 +44,10 @@ public:
 
   bool begin_I2C(uint8_t addr = BMP3XX_DEFAULT_ADDRESS,
                  TwoWire *theWire = &Wire);
-  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI);
+  bool begin_SPI(uint8_t cs_pin, SPIClass *theSPI = &SPI,
+                 uint32_t frequency = BMP3XX_DEFAULT_SPIFREQ);
   bool begin_SPI(int8_t cs_pin, int8_t sck_pin, int8_t miso_pin,
-                 int8_t mosi_pin);
+                 int8_t mosi_pin, uint32_t frequency = BMP3XX_DEFAULT_SPIFREQ);
   uint8_t chipID(void);
   float readTemperature(void);
   float readPressure(void);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BMP3XX Library
-version=2.1.4
+version=2.1.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BMP3XX series temperature/pressure sensors


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
  - It only adds an optional argument to the spi begin functions to allow users to specify a custom clock rate

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.
  - There is no check for a SPI clock that is too fast or slow. However, other Adafruit sensor driver libraries don't do this check (i.e. [Adafruit_LIS3MDL.h](https://github.com/adafruit/Adafruit_LIS3MDL))

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.
  - This code is 100% backwards compatible with the previous version

